### PR TITLE
Change Docker image, adapt for stable rust, update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,7 @@ authors = ["Michael Coyne <mikeycgto@gmail.com>"]
 hyper = { git = "https://github.com/hyperium/hyper.git", rev = "e23689122a1d2525574d144fa79ae48fccfdb964" }
 url = { version = "1.1.1" }
 uuid = { version = "0.2", features = ["v4"] }
-docopt = { version = "0.6" }
-docopt_macros = { version = "0.6" }
+docopt = { version = "0.7" }
 rustc-serialize = { version = "0.3" }
 log = { version = "0.3" }
 env_logger = { version = "0.3" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
-FROM scorpil/rust:1.16
-MAINTAINER david david@shippeo.com
+# Universal image that can build most things Rust
+FROM phusion/baseimage
 
-RUN apt-get -qq update
-RUN apt-get -qq -y --no-install-recommends install \
-	libssl-dev \
-	# ring dependencies : https://github.com/briansmith/ring/blob/master/BUILDING.md#building-the-rust-library
-	build-essential
+# stable|beta|nightly
+ARG RUST_TOOLCHAIN=stable
+ENV RUSTUP_HOME=/tmp/rustup 
+ENV RUSTUP_BIN=$RUSTUP_HOME/toolchains/${RUST_TOOLCHAIN}-x86_64-unknown-linux-gnu/bin
 
-ADD . /src
-WORKDIR /src
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common \
+			python-software-properties wget pkg-config build-essential ca-certificates curl clang libclang-dev \
+			git libssl-dev gcc sudo vim libpq-dev
+
+RUN mkdir /tmp/rustup && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+
+ADD . /code
+WORKDIR /code
 
 EXPOSE 3000
+ENV PATH=$RUSTUP_BIN:$PATH
 
 RUN cargo build --release
 CMD cargo run --release -- --bind 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ There you have it, the essence of esper!
 
 ### Building
 
-Esper can be build with a rust development environment [(nightly channel)](https://doc.rust-lang.org/book/nightly-rust.html) and `cargo` command-line tool
+Esper can be build with stable Rust and `cargo` command-line tool
 ```bash
 git clone https://github.com/mikeycgto/esper.git && cd esper
 cargo build --release 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![feature(plugin)]
-#![plugin(docopt_macros)]
-
 extern crate rustc_serialize;
 extern crate docopt;
 extern crate hyper;
@@ -8,6 +5,8 @@ extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+
+use docopt::Docopt;
 
 extern crate esper;
 
@@ -21,8 +20,7 @@ use hyper::server::{Server};
 use esper::{Access, Manager};
 use esper::handler::EventStream;
 
-docopt!(Args derive Debug, "
-esper - Event Source HTTP server, powered by hyper.
+const USAGE: &'static str = "esper - Event Source HTTP server, powered by hyper.
 
 Usage:
   esper [--bind=<bind>] [--port=<port>] [--threads=<st>]
@@ -35,7 +33,17 @@ Options:
   -b --bind=<bind>   Bind to specific IP [default: 127.0.0.1]
   -p --port=<port>   Run on a specific port number [default: 3000]
   -t --threads=<st>  Number of server threads [default: 2].
-", flag_threads: u8);
+";
+
+#[derive(Debug, RustcDecodable)]
+struct Args {
+    flag_bind: String,
+    flag_port: u32,
+    flag_threads: u8,
+    flag_version: bool,
+    flag_help: bool
+}
+
 
 fn abort(message: &'static str) -> () {
     println!("{}", message);
@@ -46,7 +54,10 @@ fn main() {
     println!("Welcome to esper -- the Event Source HTTP server, powered by hyper!\n");
     env_logger::init().unwrap_or_else(|_| abort("Failed to initialize logger!"));
 
-    let args: Args = Args::docopt().decode().unwrap_or_else(|e| e.exit());
+    let args: Args = Docopt::new(USAGE)
+                            .and_then(|d| d.decode())
+                            .unwrap_or_else(|e| e.exit());
+
     debug!("Executing with args: {:?}", args);
 
     if args.flag_version {
@@ -104,3 +115,4 @@ fn main() {
         }
     }
 }
+


### PR DESCRIPTION
Hi

first of all thanks for making Esper, server side events are great and I feel we really need Rust implementation.

Since `docopt-macros` refuse too build since `1.18`, I removed them and adapted docopt generation. I also took the liberty of replacing a Docker image, so that future builds are more robust, and images a bit smaller.

Cheers!
